### PR TITLE
Add support to connect to a running app or plugin

### DIFF
--- a/source/cpp/CMakeLists.txt
+++ b/source/cpp/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library (
   focusrite-e2e
+  STATIC
   include/focusrite/e2e/ClickableComponent.h
   include/focusrite/e2e/Command.h
   include/focusrite/e2e/CommandHandler.h
   include/focusrite/e2e/ComponentSearch.h
   include/focusrite/e2e/Event.h
+  include/focusrite/e2e/Log.h
   include/focusrite/e2e/Response.h
   include/focusrite/e2e/TestCentre.h
   source/Command.cpp
@@ -16,6 +18,7 @@ add_library (
   source/Event.cpp
   source/KeyPress.cpp
   source/KeyPress.h
+  source/Log.cpp
   source/Response.cpp
   source/TestCentre.cpp)
 
@@ -45,6 +48,20 @@ set_common_target_properties (focusrite-e2e)
 
 get_target_property (FOCUSRITE_E2E_SOURCES focusrite-e2e SOURCES)
 source_group (TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${FOCUSRITE_E2E_SOURCES})
+
+# Hide symbols
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set_target_properties(focusrite-e2e PROPERTIES
+    XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN YES
+    XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN YES
+  )
+else()
+  set_target_properties(focusrite-e2e PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+endif()
 
 if (FOCUSRITE_E2E_MAKE_TESTS)
 

--- a/source/cpp/include/focusrite/e2e/Log.h
+++ b/source/cpp/include/focusrite/e2e/Log.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace focusrite::e2e
+{
+
+enum class LogLevel
+{
+    silent,
+    verbose,
+};
+
+void log(LogLevel logLevel, const juce::String& message);
+
+}

--- a/source/cpp/include/focusrite/e2e/TestCentre.h
+++ b/source/cpp/include/focusrite/e2e/TestCentre.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <focusrite/e2e/CommandHandler.h>
 #include <memory>
 #include <optional>
+
+#include <focusrite/e2e/Log.h>
+#include <focusrite/e2e/CommandHandler.h>
 
 namespace focusrite::e2e
 {
@@ -10,13 +12,9 @@ class Event;
 class TestCentre
 {
 public:
-    enum class LogLevel
-    {
-        silent,
-        verbose,
-    };
-
-    static std::unique_ptr<TestCentre> create (LogLevel logLevel = LogLevel::silent);
+    using LogLevel = focusrite::e2e::LogLevel;
+    
+    static std::unique_ptr<TestCentre> create (LogLevel logLevel = LogLevel::silent, uint16_t port = 0);
 
     virtual ~TestCentre () = default;
 

--- a/source/cpp/source/Connection.h
+++ b/source/cpp/source/Connection.h
@@ -2,6 +2,8 @@
 
 #include <juce_core/juce_core.h>
 
+#include <focusrite/e2e/Log.h>
+
 namespace focusrite::e2e
 {
 class Connection
@@ -9,7 +11,7 @@ class Connection
     , public std::enable_shared_from_this<Connection>
 {
 public:
-    static std::shared_ptr<Connection> create (int port);
+    static std::shared_ptr<Connection> create (LogLevel logLevel, int port);
 
     ~Connection () override;
 
@@ -24,7 +26,7 @@ public:
     [[nodiscard]] bool isConnected () const;
 
 private:
-    explicit Connection (int port);
+    explicit Connection (LogLevel logLevel, int port);
 
     void run () override;
 
@@ -32,6 +34,7 @@ private:
     void preventSigPipeExceptions ();
     void notifyData (const juce::MemoryBlock & data);
 
+    LogLevel _logLevel { LogLevel::silent };
     int _port = 0;
     juce::StreamingSocket _socket;
 };

--- a/source/cpp/source/Log.cpp
+++ b/source/cpp/source/Log.cpp
@@ -1,0 +1,16 @@
+#include <juce_core/juce_core.h>
+
+#include <focusrite/e2e/Log.h>
+
+namespace focusrite::e2e
+{
+
+void log(LogLevel logLevel, const juce::String& message)
+{
+    if (logLevel == LogLevel::silent)
+        return;
+
+    juce::Logger::writeToLog (message);
+}
+
+}

--- a/source/ts/server.ts
+++ b/source/ts/server.ts
@@ -14,7 +14,7 @@ export class Server extends EventEmitter {
     }
   }
 
-  async listen(): Promise<number> {
+  async listen(port?: number): Promise<number> {
     if (this.listenSocket) {
       throw new Error('Server already running');
     }
@@ -41,7 +41,7 @@ export class Server extends EventEmitter {
         resolve(address.port);
       });
 
-      this.listenSocket?.listen();
+      this.listenSocket?.listen(port);
     });
   }
 


### PR DESCRIPTION
- Allow to connect to a running app or plugin on specific port
- Allow app or plugin to retry connection in case server is not started
- Hide focusrite e2e library symbols
- Move logging to a separate function